### PR TITLE
fix(executable): resolve links for flutter_path

### DIFF
--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -124,9 +124,10 @@ function M.get(callback)
   end
 
   if conf.flutter_path then
+    local flutter_path = fn.resolve(conf.flutter_path)
     _paths = {
-      flutter_bin = conf.flutter_path,
-      flutter_sdk = _flutter_sdk_root(conf.flutter_path),
+      flutter_bin = flutter_path,
+      flutter_sdk = _flutter_sdk_root(flutter_path),
     }
     _paths.dart_sdk = _dart_sdk_root(_paths)
     _paths.dart_bin = _flutter_sdk_dart_bin(_paths.flutter_sdk)


### PR DESCRIPTION
Currently when a users specifies a `flutter_path` value we do not resolve any symlinks unlike other points where we derive the flutter path. This PR updates the value of the flutter path to be correctly resolved.