### PR TITLE
Hide Flutter dev log from buffers list.

### DIFF
--- a/lua/flutter-tools/log.lua
+++ b/lua/flutter-tools/log.lua
@@ -110,6 +110,7 @@ function M.__resurrect()
   vim.bo[buf].modifiable = false
   vim.bo[buf].modified = false
   vim.bo[buf].buftype = "nofile"
+  vim.bo[buf].buflisted = false
 end
 
 function M.clear()

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -46,7 +46,7 @@ function M.buf_valid(bufnr, name)
   if bufnr then
     return api.nvim_buf_is_loaded(bufnr)
   end
-  return vim.fn.bufexists(target) > 0 and vim.fn.buflisted(target) > 0
+  return vim.fn.bufexists(target) > 0
 end
 
 ---Add a function to the global callback map


### PR DESCRIPTION
Flutter dev log buffer is appearing in the buffer list with a filename '__FLUTTER_DEV_LOG__'. It's handy to keep that buffer visible (in a split window), but it causes problems when cycling through buffers or resizing it.

This PR sets 'buflisted' property to false, so the buffer is not listed.

This will probably require implementing some kind of log window toggling (discussed in https://github.com/akinsho/flutter-tools.nvim/issues/84).

In general, this echoes abovementioned issue in a way to bring more consistency between log and outline windows for this plugin.