### PR TITLE
prefer the dart binary located in dart_sdk rather than flutter_sdk

### DIFF
--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -35,7 +35,7 @@ local function _dart_sdk_root(paths)
     return path.join(flutter_bin, dart_sdk)
   end
 
-  if utils.executable("dart") then return fn.resolve(fn.exepath("dart")) end
+  if utils.executable("dart") then return fn.resolve(path.dirname(path.dirname(fn.exepath("dart")))) end
 
   return ""
 end

--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -40,10 +40,11 @@ local function _dart_sdk_root(paths)
   return ""
 end
 
-local function _flutter_sdk_dart_bin(flutter_sdk)
-  -- retrieve the Dart binary from the Flutter SDK
+local function _sdk_dart_bin(paths)
+  -- retrieve the Dart binary from the Dart SDK or the Flutter SDK
   local binary_name = require("flutter-tools.utils.path").is_windows and "dart.bat" or "dart"
-  return path.join(flutter_sdk, "bin", binary_name)
+  local sdk = paths.dart_sdk or paths.flutter_sdk
+  return path.join(sdk, "bin", binary_name)
 end
 
 ---Get paths for flutter and dart based on the binary locations
@@ -85,9 +86,9 @@ local function path_from_lookup_cmd(lookup_cmd, callback)
     local result = j:result()
     local flutter_sdk_path = result[1]
     if flutter_sdk_path then
-      paths.dart_bin = _flutter_sdk_dart_bin(flutter_sdk_path)
-      paths.flutter_bin = path.join(flutter_sdk_path, "bin", "flutter")
       paths.flutter_sdk = flutter_sdk_path
+      paths.flutter_bin = path.join(flutter_sdk_path, "bin", "flutter")
+      paths.dart_bin = _sdk_dart_bin(paths)
       callback(paths)
     else
       paths = get_default_binaries()
@@ -116,7 +117,7 @@ function M.get(callback)
         fvm = true,
       }
       _paths.dart_sdk = _dart_sdk_root(_paths)
-      _paths.dart_bin = _flutter_sdk_dart_bin(_paths.flutter_sdk)
+      _paths.dart_bin = _sdk_dart_bin(_paths)
       return callback(_paths)
     end
   end
@@ -128,7 +129,7 @@ function M.get(callback)
       flutter_sdk = _flutter_sdk_root(flutter_path),
     }
     _paths.dart_sdk = _dart_sdk_root(_paths)
-    _paths.dart_bin = _flutter_sdk_dart_bin(_paths.flutter_sdk)
+    _paths.dart_bin = _sdk_dart_bin(_paths)
     return callback(_paths)
   end
 
@@ -143,7 +144,7 @@ function M.get(callback)
   if not _paths then
     _paths = get_default_binaries()
     _paths.dart_sdk = _dart_sdk_root(_paths)
-    if _paths.flutter_sdk then _paths.dart_bin = _flutter_sdk_dart_bin(_paths.flutter_sdk) end
+    if _paths.flutter_sdk then _paths.dart_bin = _sdk_dart_bin(_paths) end
   end
 
   return callback(_paths)


### PR DESCRIPTION
The `flutter` package in nix doesn't expose the dart binary in `<Flutter SDK>/bin/dart`. The binary is only found in the Dart SDK (`<Flutter SDK>/bin/cache/dart_sdk/bin/dart`).
This PR prefers the dart binary located in the Dart SDK rather than the Flutter SDK.

### Concers
This PR is ready to merge only if the dart binary is always located in the dart_sdk (which I'm pretty use is always the case, but idk).
If the dart_sdk path is found but there is no `<dart_sdk>/bin/dart` then the plugin would fail to get the dart binary. That's because the PR doesn't check if the dart binary exists, only if `paths.dart_sdk` doesn't exists then it checks `paths.flutter_sdk`.