### PR TITLE
feat: implement toggling the dev log

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ require("flutter-tools").setup {} -- use defaults
 - `FlutterSuper` - Go to super class, method using custom LSP method `dart/textDocument/super`.
 - `FlutterReanalyze` - Forces LSP server reanalyze using custom LSP method `dart/reanalyze`.
 - `FlutterRename` - Renames and updates imports if `lsp.settings.renameFilesWithClasses == "always"`
+- `FlutterLogToggle` - Toggles the log window.  
+- `FlutterLogClear` - Clears the log window.
 
 <hr/>
 

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -48,6 +48,7 @@ local function setup_commands()
     nargs = "*",
   })
   --- Log
+  command("FlutterLogToggle", log.toggle_dev_log)
   command("FlutterLogClear", log.clear)
   --- LSP
   command("FlutterSuper", lsp.dart_lsp_super)

--- a/lua/flutter-tools/ui.lua
+++ b/lua/flutter-tools/ui.lua
@@ -133,11 +133,11 @@ end
 ---@param on_open fun(buf: integer, win: integer)
 ---@return nil
 function M.open_win(opts, on_open)
-  local open_cmd = opts.open_cmd or "botright 30vnew"
+  local open_cmd = opts.open_cmd or "botright 30vsplit"
   local name = opts.filename or "__Flutter_Tools_Unknown__"
   open_cmd = fmt("%s %s", open_cmd, name)
-
   vim.cmd(open_cmd)
+
   local win = api.nvim_get_current_win()
   local buf = api.nvim_get_current_buf()
   vim.bo[buf].filetype = opts.filetype


### PR DESCRIPTION
This creates an autocommand for toggling the dev log to appear and disappear. Similar implementation to the outline window.

~~Also adjusts the default width for creating a new window, something was going wrong with the previous open win command regarding the width, when opening the toggle the second time. Tested and *seems* okay but might be worth a double check.~~