### PR TITLE
docs(README): Updates the readme with information on the lsp.cmd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ require("flutter-tools").setup {
       virtual_text = true, -- show the highlight using virtual text
       virtual_text_str = "■", -- the virtual text character to highlight
     },
+    cmd = {"command", "to", "run", "lsp"}, -- The command to run the dart lsp binary (e.g. { "/custom/path/dart", "language-server", "--protocol=lsp" })
     on_attach = my_custom_on_attach,
     capabilities = my_custom_capabilities, -- e.g. lsp_status capabilities
     --- OR you can specify a function to deactivate or change or control how the config is created

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ require("flutter-tools").setup {
       virtual_text = true, -- show the highlight using virtual text
       virtual_text_str = "■", -- the virtual text character to highlight
     },
-    cmd = {"command", "to", "run", "lsp"}, -- The command to run the dart lsp binary (e.g. { "/custom/path/dart", "language-server", "--protocol=lsp" })
+    cmd = {"command", "to", "run", "lsp"}, -- The command to run the dart lsp (e.g. { "/custom/dart/path", "language-server", "--protocol=lsp" })
     on_attach = my_custom_on_attach,
     capabilities = my_custom_capabilities, -- e.g. lsp_status capabilities
     --- OR you can specify a function to deactivate or change or control how the config is created

--- a/doc/flutter-tools.txt
+++ b/doc/flutter-tools.txt
@@ -224,7 +224,7 @@ These two keys are two ways of solving the same problem so will conflict if
 both are set.
 
 >lua
-    
+
     -- alternatively you can override the default configs
     require("flutter-tools").setup {
       ui = {
@@ -308,6 +308,7 @@ both are set.
           virtual_text = true, -- show the highlight using virtual text
           virtual_text_str = "■", -- the virtual text character to highlight
         },
+        cmd = {"command", "to", "run", "lsp"}, -- The command to run the dart lsp binary (e.g. { "/custom/path/dart", "language-server", "--protocol=lsp" })
         on_attach = my_custom_on_attach,
         capabilities = my_custom_capabilities, -- e.g. lsp_status capabilities
         --- OR you can specify a function to deactivate or change or control how the config is created

--- a/doc/flutter-tools.txt
+++ b/doc/flutter-tools.txt
@@ -308,7 +308,7 @@ both are set.
           virtual_text = true, -- show the highlight using virtual text
           virtual_text_str = "■", -- the virtual text character to highlight
         },
-        cmd = {"command", "to", "run", "lsp"}, -- The command to run the dart lsp binary (e.g. { "/custom/path/dart", "language-server", "--protocol=lsp" })
+        cmd = {"command", "to", "run", "lsp"}, -- The command to run the dart lsp binary (e.g. { "/custom/dart/path", "language-server", "--protocol=lsp" })
         on_attach = my_custom_on_attach,
         capabilities = my_custom_capabilities, -- e.g. lsp_status capabilities
         --- OR you can specify a function to deactivate or change or control how the config is created


### PR DESCRIPTION
I was having some issues with my Dart LSP not even loading. Eventually I found the answer inside https://github.com/nvim-flutter/flutter-tools.nvim/issues/369#issuecomment-2327231927 which showed an lsp "cmd" option I wasn't aware of because it was missing from the README.