### PR TITLE
feat(log): add toggle command for log buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ require("flutter-tools").setup {} -- use defaults
 - `FlutterSuper` - Go to super class, method using custom LSP method `dart/textDocument/super`.
 - `FlutterReanalyze` - Forces LSP server reanalyze using custom LSP method `dart/reanalyze`.
 - `FlutterRename` - Renames and updates imports if `lsp.settings.renameFilesWithClasses == "always"`
+- `FlutterLogClear` - Clears the log buffer.
+- `FlutterLogToggle` - Toggles the log buffer.
+
 
 <hr/>
 
@@ -253,7 +256,7 @@ require("flutter-tools").setup {
     -- takes a log_line as string argument; returns a boolean or nil;
     -- the log_line is only added to the output if the function returns true
     notify_errors = false, -- if there is an error whilst running then notify the user
-    open_cmd = "botright 30vnew", -- command to use to open the log buffer
+    open_cmd = "15split", -- command to use to open the log buffer
     focus_on_open = true, -- focus on the newly opened log window
   },
   dev_tools = {

--- a/doc/flutter-tools.txt
+++ b/doc/flutter-tools.txt
@@ -198,6 +198,8 @@ APP VERSION
 - `FlutterSuper` - Go to super class, method using custom LSP method `dart/textDocument/super`.
 - `FlutterReanalyze` - Forces LSP server reanalyze using custom LSP method `dart/reanalyze`.
 - `FlutterRename` - Renames and updates imports if `lsp.settings.renameFilesWithClasses == "always"`
+- `FlutterLogClear` - Clears the log buffer.
+- `FlutterLogToggle` - Toggles the log buffer.
 
 
 FLUTTERRUN ~
@@ -289,7 +291,7 @@ both are set.
         -- takes a log_line as string argument; returns a boolean or nil;
         -- the log_line is only added to the output if the function returns true
         notify_errors = false, -- if there is an error whilst running then notify the user
-        open_cmd = "botright 30vnew", -- command to use to open the log buffer
+        open_cmd = "15split", -- command to use to open the log buffer
         focus_on_open = true, -- focus on the newly opened log window
       },
       dev_tools = {

--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -46,6 +46,7 @@ local function setup_commands()
   })
   --- Log
   command("FlutterLogClear", log.clear)
+  command("FlutterLogToggle", log.toggle)
   --- LSP
   command("FlutterSuper", lsp.dart_lsp_super)
   command("FlutterReanalyze", lsp.dart_reanalyze)

--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -66,7 +66,7 @@ end
 ---@param is_err boolean if this is stdout or stderr
 local function on_run_data(is_err, data)
   if is_err and config.dev_log.notify_errors then ui.notify(data, ui.ERROR, { timeout = 5000 }) end
-  dev_log.log(data, config.dev_log)
+  dev_log.log(data)
 end
 
 local function shutdown()

--- a/lua/flutter-tools/log.lua
+++ b/lua/flutter-tools/log.lua
@@ -1,6 +1,7 @@
 local lazy = require("flutter-tools.lazy")
 local ui = lazy.require("flutter-tools.ui") ---@module "flutter-tools.ui"
 local utils = lazy.require("flutter-tools.utils") ---@module "flutter-tools.utils"
+local config = lazy.require("flutter-tools.config") ---@module "flutter-tools.config"
 
 local api = vim.api
 local fmt = string.format
@@ -91,8 +92,8 @@ end
 --- Open a log showing the output from a command
 --- in this case flutter run
 ---@param data string
----@param opts table
-function M.log(data, opts)
+function M.log(data)
+  local opts = config.dev_log
   if opts.enabled then
     if not exists() then create(opts) end
     if opts.filter and not opts.filter(data) then return end
@@ -115,6 +116,21 @@ function M.clear()
     api.nvim_buf_set_lines(M.buf, 0, -1, false, {})
     vim.bo[M.buf].modifiable = false
   end
+end
+
+M.toggle = function()
+  local wins = vim.api.nvim_list_wins()
+  for _, id in pairs(wins) do
+    local bufnr = vim.api.nvim_win_get_buf(id)
+    if vim.api.nvim_buf_get_name(bufnr):match(".*/([^/]+)$") == M.filename then
+      return vim.api.nvim_win_close(id, true)
+    end
+  end
+  create(config.dev_log)
+  autoscroll(M.buf, M.win)
+  -- Auto scroll to bottom
+  local buf_length = vim.api.nvim_buf_line_count(M.buf)
+  pcall(vim.api.nvim_win_set_cursor, M.win, { buf_length, 0 })
 end
 
 return M


### PR DESCRIPTION
- Added a new command `FlutterLogToggle` to toggle the visibility of the log buffer.
- Updated the documentation to include the new command. 
- Modified the log function to use the same buffer number when appending lines.
- Adjusted the open command for the log buffer to use a horizontal split.