### PR TITLE
fix(commands): make inspect widget command work in debug runner

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -350,10 +350,10 @@ function M.open_dev_tools(quiet) send("open_dev_tools", quiet) end
 function M.generate(quiet) send("generate", quiet) end
 
 ---@param quiet boolean
-function M.widget_inspector(quiet) send("inspect", quiet) end
+function M.inspect_widget(quiet) send("inspect_widget", quiet) end
 
 ---@param quiet boolean
-function M.construction_lines(quiet) send("construction_lines", quiet) end
+function M.paint_baselines(quiet) send("paint_baselines", quiet) end
 
 -----------------------------------------------------------------------------//
 -- Pub commands

--- a/lua/flutter-tools/menu.lua
+++ b/lua/flutter-tools/menu.lua
@@ -151,16 +151,16 @@ function M.commands(opts)
         command = commands.detach,
       },
       {
-        id = "flutter-tools-widget-inspector",
-        label = "Widget Inspector",
+        id = "flutter-tools-inspect-widget",
+        label = "Inspect Widget",
         hint = "Toggle the widget inspector",
-        command = commands.widget_inspector,
+        command = commands.inspect_widget,
       },
       {
-        id = "flutter-tools-construction-lines",
-        label = "Construction Lines",
-        hint = "Display construction lines",
-        command = commands.construction_lines,
+        id = "flutter-tools-paint-baselines",
+        label = "Paint Baselines",
+        hint = "Toggle paint baselines",
+        command = commands.paint_baselines,
       },
     }
   else

--- a/lua/flutter-tools/runners/debugger_runner.lua
+++ b/lua/flutter-tools/runners/debugger_runner.lua
@@ -18,8 +18,6 @@ local command_requests = {
   restart = "hotRestart",
   reload = "hotReload",
   quit = "terminate",
-  inspect = "widgetInspector",
-  construction_lines = "constructionLines",
 }
 
 function DebuggerRunner:is_running() return dap.session() ~= nil end
@@ -208,7 +206,11 @@ function DebuggerRunner:send(cmd, quiet)
   end
   local service_activation_params = vm_service_extensions.get_request_params(cmd)
   if service_activation_params then
-    dap.session():request("callService", service_activation_params)
+    dap.session():request("callService", service_activation_params, function(err, _)
+      if err and not quiet then
+        ui.notify("Error calling service " .. cmd .. ": " .. err, ui.ERROR)
+      end
+    end)
     return
   end
   if not quiet then

--- a/lua/flutter-tools/runners/job_runner.lua
+++ b/lua/flutter-tools/runners/job_runner.lua
@@ -15,8 +15,8 @@ local command_keys = {
   quit = "q",
   visual_debug = "p",
   detach = "d",
-  inspect = "i",
-  construction_lines = "p",
+  inspect_widget = "i",
+  paint_baselines = "p",
   open_dev_tools = "v",
   generate = "g",
 }

--- a/lua/flutter-tools/runners/vm_service_extensions.lua
+++ b/lua/flutter-tools/runners/vm_service_extensions.lua
@@ -12,6 +12,8 @@ local service_activation_requests = {
   performance_overlay = "ext.flutter.showPerformanceOverlay",
   repaint_rainbow = "ext.flutter.repaintRainbow",
   slow_animations = "ext.flutter.timeDilation",
+  inspect_widget = "ext.flutter.inspector.show",
+  paint_baselines = "ext.flutter.debugPaintBaselinesEnabled",
 }
 
 local toggle_extension_state_keys = {
@@ -19,6 +21,8 @@ local toggle_extension_state_keys = {
   performance_overlay = "enabled",
   repaint_rainbow = "enabled",
   slow_animations = "timeDilation",
+  inspect_widget = "enabled",
+  paint_baselines = "enabled",
 }
 
 local function toggle_value(request)
@@ -30,11 +34,7 @@ local function toggle_value(request)
       return "5.0"
     end
   end
-  if value == "true" then
-    return "false"
-  else
-    return "true"
-  end
+  return not value
 end
 
 ---@type flutter.VmServiceExtensions


### PR DESCRIPTION
- Rename widget_inspector to inspect_widget for consistency
- Rename construction_lines to paint_baselines to match Flutter API
- Add error handling when calling VM service extensions
- Fix toggle value logic for VM service extensions