### PR TITLE
Added option to disable ftplugin

### DIFF
--- a/ftplugin/dart/init.lua
+++ b/ftplugin/dart/init.lua
@@ -1,3 +1,9 @@
+-- See section 'DISABLING' in :h ftplugin
+if vim.b.flutter_tools_did_ftplugin then
+  return
+end
+vim.b.flutter_tools_did_ftplugin = 1
+
 require("flutter-tools.lsp").attach()
 
 vim.opt_local.comments = [[sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://]]


### PR DESCRIPTION
This PR adds the buffer scoped variable `flutter_tools_did_ftplugin`.

With this variable the user can manually disable the filetype plugin code bundled with `flutter-tools.nvim`. This can be useful in case someone wants different configuration options for dart only projects (like CLI tools, etc.) which are not dependent on the Flutter SDK. 

See my [init.lua](https://gitlab.com/obemu/init.lua/-/blob/master/after/plugin/20_setup_flutter_dart.lua?ref_type=heads) for an example on how that could be used.