### PR TITLE
fix: fix dap crash on BufWritePost

### DIFF
--- a/lua/flutter-tools/runners/debugger_runner.lua
+++ b/lua/flutter-tools/runners/debugger_runner.lua
@@ -282,7 +282,7 @@ function DebuggerRunner:send(cmd, quiet)
   end
   local request = command_requests[cmd]
   if request ~= nil then
-    dap.session():request(request)
+    dap.session():request(request, nil, function() end)
     return
   end
   local service_activation_params = vm_service_extensions.get_request_params(cmd)


### PR DESCRIPTION
DAP automatically detects async runtime and tries to yield across C-call. Adding empty callback fixes it.

```
Error detected while processing BufWritePost Autocommands for "*.dart":
Error executing lua callback: ...tools.nvim/lua/flutter-tools/runners/debugger_runner.lua:285: attempt to yield across C-call boundary
stack traceback:
        [C]: in function 'request'
        ...tools.nvim/lua/flutter-tools/runners/debugger_runner.lua:285: in function 'send'
        ...m/lazy/flutter-tools.nvim/lua/flutter-tools/commands.lua:337: in function 'send'
        ...m/lazy/flutter-tools.nvim/lua/flutter-tools/commands.lua:345: in function 'reload'
        ...share/nvim/lazy/flutter-tools.nvim/lua/flutter-tools.lua:102: in function <...share/nvim/lazy/flutter-tools.nvim/lua/flutter-tools.lua:102>
```