### PR TITLE
Made function 'start' in 'lua/flutter-tools.lua' public

### DIFF
--- a/lua/flutter-tools.lua
+++ b/lua/flutter-tools.lua
@@ -64,10 +64,7 @@ function M.start()
   if _has_started then return end
 
   if not _has_setup then
-    ui.notify(
-      "Cannot start because the plugin has not been setup yet.",
-      ui.ERROR
-    )
+    ui.notify("Cannot start because the plugin has not been setup yet.", ui.ERROR)
     return
   end
 


### PR DESCRIPTION
This PR changes the visibility of the function `start` in `lua/flutter-tools.lua` from private to public.

Currently, it is not possible to execute user commands from `flutter-tools` (`FlutterRun`, `FlutterDebug`, ...) before a `.dart` or the `pubspec.yaml` file has been entered. These commands can only be used once the `start` function, which registers them, is called. The problem is, that instead of calling `start` in `setup`, it is called once a `.dart` or the `pubspec.yaml` file is entered.

This change allows the user to call `flutter.start()` in their `init.lua` (or local `.nvim.lua`) file, to register all user commands. Therefore, the user is not required to enter a `.dart`/`pubspec.yaml` file to run their app and view log messages.