### PR TITLE
fix(flutter-debug): pass run options to runner callbacks

### DIFF
--- a/lua/flutter-tools/runners/debugger_runner.lua
+++ b/lua/flutter-tools/runners/debugger_runner.lua
@@ -143,6 +143,7 @@ local function register_dap_listeners(on_run_data, on_run_exit)
 end
 
 function DebuggerRunner:run(
+  opts,
   paths,
   args,
   cwd,
@@ -166,7 +167,7 @@ function DebuggerRunner:run(
       end
     end,
     function(before_start_logs)
-      on_run_exit(before_start_logs, args, project_config, selected_launch_config)
+      on_run_exit(before_start_logs, args, opts, project_config, selected_launch_config)
     end
   )
 

--- a/lua/flutter-tools/runners/job_runner.lua
+++ b/lua/flutter-tools/runners/job_runner.lua
@@ -24,6 +24,7 @@ local command_keys = {
 function JobRunner:is_running() return run_job ~= nil end
 
 function JobRunner:run(
+  opts,
   paths,
   args,
   cwd,
@@ -53,7 +54,9 @@ function JobRunner:run(
       dev_tools.handle_log(data)
     end),
     on_stderr = vim.schedule_wrap(function(_, data, _) on_run_data(true, data) end),
-    on_exit = vim.schedule_wrap(function(j, _) on_run_exit(j:result(), args, project_config) end),
+    on_exit = vim.schedule_wrap(
+      function(j, _) on_run_exit(j:result(), args, opts, project_config) end
+    ),
   })
   run_job:start()
 end


### PR DESCRIPTION
This fixes `FlutterDebug` command when multiple devices are available. Previously `force_debug` option was not passed to `on_run_exit` callback