### PR TITLE
Bugfix in module executable.lua on Windows

### DIFF
--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -103,6 +103,7 @@ local function _flutter_bin_from_fvm()
   local fvm_root =
     fs.dirname(fs.find(".fvm", { path = luv.cwd(), upward = true, type = "directory" })[1])
   local flutter_bin_symlink = path.join(fvm_root, ".fvm", "flutter_sdk", "bin", "flutter")
+  flutter_bin_symlink = fn.exepath(flutter_bin_symlink)
   local flutter_bin = luv.fs_realpath(flutter_bin_symlink)
   if path.exists(flutter_bin_symlink) and path.exists(flutter_bin) then return flutter_bin end
 end


### PR DESCRIPTION
Now using 'vim.fn.exepath' to retrieve the correct value for the flutter executable, when using fvm on windows. Previously the plugin set the flutter executable to the UNIX script ("flutter") but Windows has its' own version ("flutter.bat").