### PR TITLE
Check vim.fn.has explicitly for 1

### DIFF
--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -36,7 +36,7 @@ local function validate_prefs(prefs)
       end
     )
   end
-  if vim.fn.has("nvim-0.11") then
+  if vim.fn.has("nvim-0.11") == 1 then
     vim.validate("outline", prefs.outline, "table", true)
     vim.validate("dev_log", prefs.dev_log, "table", true)
     vim.validate("closing_tags", prefs.closing_tags, "table", true)


### PR DESCRIPTION
`vim.fn.has` returns a number, `0` or `1`, analogous to vimscript. But `0` isn't falsy in lua, but only `false` and `nil`. See https://github.com/nvim-flutter/flutter-tools.nvim/issues/461.