### PR TITLE
fix(fvm/windows): append '.bat' extention to flutter path

### DIFF
--- a/lua/flutter-tools/executable.lua
+++ b/lua/flutter-tools/executable.lua
@@ -102,7 +102,8 @@ end
 local function _flutter_bin_from_fvm()
   local fvm_root =
     fs.dirname(fs.find(".fvm", { path = luv.cwd(), upward = true, type = "directory" })[1])
-  local flutter_bin_symlink = path.join(fvm_root, ".fvm", "flutter_sdk", "bin", "flutter")
+  local binary_name = path.is_windows and "flutter.bat" or "flutter"
+  local flutter_bin_symlink = path.join(fvm_root, ".fvm", "flutter_sdk", "bin", binary_name)
   flutter_bin_symlink = fn.exepath(flutter_bin_symlink)
   local flutter_bin = luv.fs_realpath(flutter_bin_symlink)
   if path.exists(flutter_bin_symlink) and path.exists(flutter_bin) then return flutter_bin end


### PR DESCRIPTION
### Problem

The plugin does not work with FVM on Windows. I tested this on two separate projects using Flutter versions 3.16.0 and 3.27.0.

When running the `FlutterRun` command, the following error occurs:

```swift
Error executing Lua callback:
...plenary/job.lua:406: Failed to spawn process:
command = "C:\\Users\\vasil\\fvm\\versions\\3.27.0\\bin\\flutter"
pid = "ENOENT: no such file or directory"
```

This happens because the plugin tries to run flutter directly, but on Windows the actual executable is `flutter.bat`.

### Solution

If `path.is_windows == true`, we now append `.bat` to the path of the flutter binary. This fixes the issue and allows flutter-tools.nvim to work correctly with FVM on Windows.

I've been using this fix for several weeks without issues.

### Environment

OS: Windows 11 Home
fvm: v3.2.1
flutter-tools.nvim: 8fa438f
Neovim:  v0.10.4

### Minimal Config to Reproduce

```lua
return {
  "nvim-flutter/flutter-tools.nvim",
  ft = "dart",
  dependencies = {
    "nvim-lua/plenary.nvim",
    "mfussenegger/nvim-dap",
  },
  config = function()
    require("flutter-tools").setup({
      fvm = true
    })
  end,
}
```