### PR TITLE
Fix flutter version check

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -282,6 +282,25 @@ local function run(opts, project_conf, launch_config)
     local is_flutter_project = has_flutter_dependency_in_pubspec(cwd)
     if is_flutter_project then
       ui.notify("Starting flutter project...")
+
+      -- Prepend '--no-version-check' so that Flutter CLI tool does
+      -- not look for a new version.
+      --
+      -- Executing any command with the Flutter CLI tool makes the tool look
+      -- for a new version and optionally prints this banner:
+      --
+      -- ┌─────────────────────────────────────────────────────────┐
+      -- │ A new version of Flutter is available!                  │
+      -- │                                                         │
+      -- │ To update to the latest version, run "flutter upgrade". │
+      -- └─────────────────────────────────────────────────────────┘
+      --
+      -- The problem is that this banner causes errors when parsing the
+      -- output of the running command. To fix this, we omit the version
+      -- check by default, but give the user the option to enable it.
+      if not config.flutter_version_check then
+        args = table.insert(args, 1, "--no-version-check")
+      end
     else
       ui.notify("Starting dart project...")
     end

--- a/lua/flutter-tools/config.lua
+++ b/lua/flutter-tools/config.lua
@@ -74,6 +74,11 @@ local config = {
   pre_run_callback = nil,
   root_patterns = { ".git", "pubspec.yaml" },
   fvm = false,
+  --- True if the Flutter CLI tool should check if a new version is
+  --- available before executing.
+  ---
+  --- Defaults to false.
+  flutter_version_check = false,
   widget_guides = {
     enabled = false,
     debug = false,


### PR DESCRIPTION
Prepend '--no-version-check' so that Flutter CLI tool does
not look for a new version.

Executing any command with the Flutter CLI tool makes the tool look
for a new version and optionally prints this banner:

```
┌─────────────────────────────────────────────────────────┐
│ A new version of Flutter is available!                  │
│                                                         │
│ To update to the latest version, run "flutter upgrade". │
└─────────────────────────────────────────────────────────┘
```

The problem is that this banner causes errors when parsing the
output of the running command. To fix this, we omit the version
check by default, but give the user the option to enable it.
