### PR TITLE
feat: improves project root detection by always going up the directory tree until we find a project root marker

### DIFF
--- a/lua/flutter-tools/lsp/init.lua
+++ b/lua/flutter-tools/lsp/init.lua
@@ -166,7 +166,15 @@ function M.restart()
 end
 
 ---@return string?
-function M.get_lsp_root_dir()
+function M.get_project_root_dir()
+  local conf = require("flutter-tools.config")
+  local current_buffer_path = path.current_buffer_path()
+  local root_path = lsp_utils.is_valid_path(current_buffer_path)
+      and path.find_root(conf.root_patterns, current_buffer_path)
+    or nil
+
+  if root_path ~= nil then return root_path end
+
   local client = lsp_utils.get_dartls_client()
   return client and client.config.root_dir or nil
 end
@@ -260,7 +268,7 @@ function M.attach()
   if not is_valid_path(buffer_path) then return end
 
   get_server_config(user_config, function(c)
-    c.root_dir = M.get_lsp_root_dir()
+    c.root_dir = M.get_project_root_dir()
       or fs.dirname(fs.find(conf.root_patterns, {
         path = buffer_path,
         upward = true,

--- a/lua/flutter-tools/lsp/utils.lua
+++ b/lua/flutter-tools/lsp/utils.lua
@@ -11,4 +11,16 @@ local get_clients = vim.fn.has("nvim-0.10") == 1 and lsp.get_clients or lsp.get_
 ---@return vim.lsp.Client?
 function M.get_dartls_client(bufnr) return get_clients({ name = M.SERVER_NAME, bufnr = bufnr })[1] end
 
+--- Checks if buffer path is valid for attaching LSP
+--- @param buffer_path string
+--- @return boolean
+function M.is_valid_path(buffer_path)
+  if buffer_path == "" then return false end
+
+  local start_index, _, uri_prefix = buffer_path:find("^(%w+://).*")
+  -- Do not attach LSP if file URI prefix is not file.
+  -- For example LSP will not be attached for diffview:// or fugitive:// buffers.
+  return not start_index or uri_prefix == "file://"
+end
+
 return M

--- a/lua/flutter-tools/utils/config_utils.lua
+++ b/lua/flutter-tools/utils/config_utils.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+local lazy = require("flutter-tools.lazy")
+local path = lazy.require("flutter-tools.utils.path") ---@module "flutter-tools.utils.path"
+local ui = lazy.require("flutter-tools.ui") ---@module "flutter-tools.ui"
+local lsp = lazy.require("flutter-tools.lsp") ---@module "flutter-tools.utils"
+
+--- Gets the appropriate cwd
+---@param project_conf flutter.ProjectConfig?
+---@returns string?
+function M.get_cwd(project_conf)
+  if project_conf and project_conf.cwd then
+    local resolved_path = path.get_absolute_path(project_conf.cwd)
+    if not vim.loop.fs_stat(resolved_path) then
+      return ui.notify("Provided cwd does not exist: " .. resolved_path, ui.ERROR)
+    end
+    return resolved_path
+  end
+  return lsp.get_project_root_dir()
+end
+
+return M

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -44,8 +44,8 @@ end
 ---Find an item in a list based on a compare function
 ---@generic T
 ---@param compare fun(item: T): boolean
----@param list `T`
----@return `T`?
+---@param list T[]
+---@return T?
 function M.find(list, compare)
   for _, item in ipairs(list) do
     if compare(item) then return item end

--- a/lua/flutter-tools/utils/path.lua
+++ b/lua/flutter-tools/utils/path.lua
@@ -3,6 +3,7 @@ local lazy = require("flutter-tools.lazy")
 local utils = lazy.require("flutter-tools.utils") ---@module "flutter-tools.utils"
 
 local luv = vim.loop
+local api = vim.api
 local M = {}
 
 function M.exists(filename)
@@ -82,7 +83,10 @@ function M.iterate_parents(path)
   return it, path, path
 end
 
+---@param root string?
+---@param path string?
 function M.is_descendant(root, path)
+  if not root then return false end
   if not path then return false end
 
   local function cb(dir, _) return dir == root end
@@ -111,6 +115,28 @@ function M.find_root(patterns, startpath)
     end
   end
   return M.search_ancestors(startpath, matcher)
+end
+
+function M.current_buffer_path()
+  local current_buffer = api.nvim_get_current_buf()
+  local current_buffer_path = api.nvim_buf_get_name(current_buffer)
+  return current_buffer_path
+end
+
+function M.get_absolute_path(input_path)
+  -- Check if the provided path is an absolute path
+  if
+    vim.fn.isdirectory(input_path) == 1
+    and not input_path:match("^/")
+    and not input_path:match("^%a:[/\\]")
+  then
+    -- It's a relative path, so expand it to an absolute path
+    local absolute_path = vim.fn.fnamemodify(input_path, ":p")
+    return absolute_path
+  else
+    -- It's already an absolute path
+    return input_path
+  end
 end
 
 return M


### PR DESCRIPTION
This fixes the use of commands in monorepos as we always go up the directory tree searching for the nearest project root marker,
instead of relying on the LSP's root dir which is set to be the project root of whichever project was open when the LSP got attached.