### PR TITLE
docs(README): fixes small grammartical typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ require("flutter-tools").setup {
     -- Whether to call toString() on objects in debug views like hovers and the
     -- variables list.
     -- Invoking toString() has a performance cost and may introduce side-effects,
-    -- although users may expected this functionality. null is treated like false.
+    -- although users may expect this functionality. null is treated like false.
     evaluate_to_string_in_debug_views = true,
     -- You can use the `debugger.register_configurations` to register custom runner configuration (for example for different targets or flavor). Plugin automatically registers the default configuration, but you can override it or add new ones.
     -- register_configurations = function(paths)


### PR DESCRIPTION
Just a simple grammatical fix in the README.md file