### PR TITLE
Fix DevTools URL opening on Windows

### DIFF
--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -45,17 +45,17 @@ end
 
 ---@param url string
 local function open_dev_tools(url)
-  local open_command = utils.open_command()
+  local open_command, args = utils.open_command()
   if not open_command then
     return ui.notify(
       "Sorry your Operating System is not supported, please raise an issue",
       ui.ERROR
     )
   end
-
+  table.insert(args, url)
   Job:new({
     command = open_command,
-    args = { url },
+    args = args,
     detached = true,
   }):start()
 end

--- a/lua/flutter-tools/utils/init.lua
+++ b/lua/flutter-tools/utils/init.lua
@@ -98,9 +98,9 @@ function M.get_hl(name, attribute)
 end
 
 function M.open_command()
-  if path.is_mac then return "open" end
-  if path.is_linux then return "xdg-open" end
-  if path.is_windows then return "explorer" end
+  if path.is_mac then return "open", {} end
+  if path.is_linux then return "xdg-open", {} end
+  if path.is_windows then return "cmd.exe", { "/c", "start" } end
   return nil, nil
 end
 


### PR DESCRIPTION
### Problem

I wasn’t able to open DevTools either via :FlutterOpenDevTools or automatically when starting a debug session.
This issue has existed for several months, but I managed by manually running DevTools with `fvm dart devtools` and copying the URL from the REPL.

<img width="1184" height="674" alt="Screenshot 2025-09-27 163535" src="https://github.com/user-attachments/assets/d8cc7d62-734a-4908-ac97-bb6f70dce27c" />

### Solution

The root cause was the use of the `explorer` command on Windows. explorer truncated the URL and opened an invalid path. I replaced it with `start` and adjusted the method so that it executes successfully without raising `ENOENT: no such file or directory`.

### Environment
- **OS**: Windows 11 Home
- **GNU bash**: 5.2.37(1)-release (x86_64-pc-msys)
- **FVM**: v3.2.1
- **flutter-tools.nvim**: Commit 65b7399
- **Neovim**: v0.11.4