### PR TITLE
Fix "new Flutter Version" error on FlutterRun

### DIFF
--- a/lua/flutter-tools/banner.lua
+++ b/lua/flutter-tools/banner.lua
@@ -1,0 +1,147 @@
+local lazy = require("flutter-tools.lazy")
+local executable = lazy.require("flutter-tools.executable") ---@module "flutter-tools.executable"
+local Job = require("plenary.job") ---@module "plenary.job"
+
+---@class flutter.DetectedBanners
+---
+--- True, if the banner that matches `PATTERNS.FLUTTER_NEW_VERSION` has been
+--- detected.
+---
+--- This banner will be detected if the file
+--- `$FLUTTER_SDK/bin/cache/flutter_version_check.stamp` does not exist, or
+--- reached a certain age. (Assuming `$FLUTTER_SDK` is the path to the directory
+--- that contains your Flutter SDK).
+---
+--- See the [version.dart from the Flutter SDK](https://github.com/flutter/flutter/blob/3.35.7/packages/flutter_tools/lib/src/version.dart#L1303).
+---@field has_flutter_new_version boolean
+---
+--- True, if the banner that matches `PATTERNS.FLUTTER_WELCOME` has been
+--- detected.
+---
+--- This banner will be detected if the file `$HOME/.config/flutter/tool_state`
+--- does not exist, or you changed your Flutter SDK to one with a different
+--- welcome banner.
+---
+--- See the [first_run.dart from the Flutter SDK](https://github.com/flutter/flutter/blob/3.35.7/packages/flutter_tools/lib/src/reporting/first_run.dart#L13).
+---@field has_flutter_welcome boolean
+
+---@private
+---@alias flutter.internal.OnBannersClearedListener fun(detect_banners: flutter.DetectedBanners):nil
+
+---@type flutter.DetectedBanners?
+local cached_banners = nil
+
+---@type flutter.internal.OnBannersClearedListener[]
+local on_cleared_listeners = {}
+
+local has_started_cleansing = false
+
+local M = {
+  PATTERNS = {
+    FLUTTER_NEW_VERSION = "A new version of Flutter is available!",
+    FLUTTER_WELCOME = "Welcome to Flutter!",
+  },
+}
+
+---@param lines string[]
+---@return flutter.DetectedBanners
+local function detect_banners(lines)
+  ---@type flutter.DetectedBanners
+  local banners = {
+    has_flutter_new_version = false,
+    has_flutter_welcome = false,
+  }
+
+  for _, line in ipairs(lines) do
+    if nil ~= line:match(M.PATTERNS.FLUTTER_NEW_VERSION) then
+      banners.has_flutter_new_version = true
+    end
+
+    if nil ~= line:match(M.PATTERNS.FLUTTER_WELCOME) then banners.has_flutter_welcome = true end
+  end
+
+  return banners
+end
+
+--- Calls every listener from `on_cleared_listeners`, once `do_clear_banners` is
+--- done. Internally caches all listeners and then resets `on_cleared_listeners`
+--- to an empty table.
+---
+---@param detected_banners flutter.DetectedBanners
+local function on_cleared_banners(detected_banners)
+  local listeners = vim.deepcopy(on_cleared_listeners)
+  on_cleared_listeners = {}
+  vim.schedule(function()
+    for _, cb in ipairs(listeners) do
+      cb(detected_banners)
+    end
+  end)
+end
+
+local function do_clear_banners(is_flutter_project)
+  assert(nil == cached_banners)
+  assert(not has_started_cleansing)
+
+  has_started_cleansing = true
+
+  executable.get(function(paths)
+    if is_flutter_project then
+      Job:new({
+        command = paths.flutter_bin,
+        args = { "--version" },
+        enable_recording = true,
+        on_exit = function(self, code, _)
+          -- Exit code should always be 0.
+          assert(0 == code)
+
+          -- 'flutter --version' writes everything to STDOUT including the
+          -- "Welcome" and "New Flutter Version" banner.
+          ---@type string[]
+          local lines = self:result()
+
+          local banners = detect_banners(lines)
+          cached_banners = banners
+
+          on_cleared_banners(cached_banners)
+        end,
+      }):start()
+    else
+      -- Only flutter CLI shows startup banners that interfer with the
+      -- Debug-/Jobrunner.
+      --
+      -- dart CLI does currently not show anything, maybe there will
+      -- be a banner in the future.
+      cached_banners = {
+        has_flutter_welcome = false,
+        has_flutter_new_version = false,
+      }
+
+      on_cleared_banners(cached_banners)
+    end
+  end)
+end
+
+--- Clear and detect any startup banners from the Flutter or Dart CLI tool.
+--- `on_cleared` is called, after all banners have been cleared.
+---
+---@param is_flutter_project boolean
+---@param on_cleared fun(detected_banners: flutter.DetectedBanners)
+function M.clear_startup_banners(is_flutter_project, on_cleared)
+  if nil ~= cached_banners then
+    vim.schedule(function() on_cleared(cached_banners) end)
+    return
+  end
+
+  table.insert(on_cleared_listeners, on_cleared)
+
+  if not has_started_cleansing then do_clear_banners(is_flutter_project) end
+end
+
+--- Reset the internally cached banners.
+function M.reset_cache()
+  cached_banners = nil
+  on_cleared_listeners = {}
+  has_started_cleansing = false
+end
+
+return M


### PR DESCRIPTION
# About

This PR implements a fix for #473.

# Problem

The first time a user executes **any** command or sub-command of the `flutter` CLI tool, they are greeted with the [`Welcome to Flutter!` banner](https://github.com/flutter/flutter/blob/3.35.7/packages/flutter_tools/lib/src/reporting/first_run.dart#L13) and if their Flutter SDK is not up-to-date, or if it has been a while since the last time they executed any command, they are also greeted with the  [`New Flutter Version` banner](https://github.com/flutter/flutter/blob/3.35.7/packages/flutter_tools/lib/src/version.dart#L1303). Both may be displayed at the same time.

These banners are always printed to STDOUT, if the conditions explained above are met, including running the Flutter debug adapter (`flutter debug_adapter`), which is executed when running the command `FlutterRun`. This interferes with `nvim-dap`s ability to parse JsonRPC messages, which in turn causes the internal parser loop of `nvim-dap` to crash, resulting in this error:

```
.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: .../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:30: Content-Length not found in headers: 
┌─────────────────────────────────────────────────────────┐
│ A new version of Flutter is available!                  │
│                                                         │
│ To update to the latest version, run "flutter upgrade". │
└─────────────────────────────────────────────────────────┘

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/to/crash-reporting                                     ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use                                    ║
  ║ 'flutter config --no-cli-animations'.                                      ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Content-Length: 584
Content-Type: application/vscode-jsonrpc; charset=utf-8

stack traceback:
	[C]: in function 'parse_chunk'
	.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: in function <.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:85>
Error executing callback:
.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: cannot resume dead coroutine
stack traceback:
	[C]: in function 'parse_chunk'
	.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: in function <.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:85>
Error executing callback:
.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: cannot resume dead coroutine
stack traceback:
	[C]: in function 'parse_chunk'
	.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: in function <.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:85>
Error executing callback:
.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: cannot resume dead coroutine
stack traceback:
	[C]: in function 'parse_chunk'
	.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:97: in function <.../.local/share/nvim/plugged/nvim-dap/lua/dap/rpc.lua:85>
```

# Fix

## My Solution

As I can't modify the code of the `nvim-dap` plugin to ignore these banners, I needed to prevent them from showing up. This has been implemented with the `banner.lua` module. This new module exposes two public functions:

* `clear_startup_banners(...)` and
* `reset_cache()`

Executing `clear_startup_banners(...)` executes the `flutter` CLI tool in the background and detects any banners, after the command is done the API user receives table with flags set for each banner. This method is used in `commands.lua`, before the `DebugRunner:run` or `JobRunner:run` method gets executed, which allows this plugin to inform the user of a new Flutter SDK version and the `Runner` to execute without triggering any errors.

## Another possible Solution

To create a custom script for each platform (Windows and Unix) that executes the `flutter debug_adapter` command and detects any banners. The scripts would then be used to register a debug adapter in `nvim-dap`, for example:

```
    ...
    dap.adapters.dart = {
      type = "executable",
      command = is_windows and custom_flutter_dap.bat or custom_flutter_dap.sh
      args = { },
    }
    ...
```

**NOTE:** I haven't tested this second solution, it is just something I thought of.

# Testing

You can manually trigger the banners to be shown again by deleting certain files.

* Delete `$FLUTTER_SDK/bin/cache/flutter_version_check.stamp` for the `New Flutter Version` banner.
* Delete `$HOME/.config/flutter/tool_state` for the `Welcome to Flutter` banner.