### PR TITLE
Fix file URI handling on Windows when jumping to source from Inspect Widget

### DIFF
--- a/lua/flutter-tools/runners/debugger_runner.lua
+++ b/lua/flutter-tools/runners/debugger_runner.lua
@@ -146,6 +146,10 @@ local function handle_inspect_event(isolate_id)
 
     if location and location.file and location.line then
       local file = location.file:gsub("^file://", "")
+      if vim.loop.os_uname().sysname == "Windows_NT" then
+        -- On Windows, the file URI may start with an extra slash
+        file = file:gsub("^/", "")
+      end
       vim.schedule(function()
         vim.cmd("edit " .. vim.fn.fnameescape(file))
         vim.api.nvim_win_set_cursor(0, { location.line, (location.column or 1) - 1 })


### PR DESCRIPTION
I added a platform check for windows, and if true, I remove any trailing forward slash from the file's URI.

This fixes the error on my machine, and shouldn't introduce any issues for those who aren't on Windows. As far as I'm aware, there's no way for a valid Windows URI to start with a `/`.

Thanks!