### PR TITLE
Unclutter error notifications

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -75,7 +75,9 @@ end
 ---Handle output from flutter run command
 ---@param is_err boolean if this is stdout or stderr
 local function on_run_data(is_err, data)
-  if is_err and config.dev_log.notify_errors then ui.notify(data, ui.ERROR, { timeout = 5000 }) end
+  if is_err and config.dev_log.notify_errors then
+      ui.notify("An error has occured! Check logs", ui.ERROR, { timeout = 5000, once = true })
+  end
   dev_log.log(data)
 end
 


### PR DESCRIPTION
When enabling `dev_log.notify_errors`, the plugin starts spamming with every line of the error message as a separate notification, which you have to click through repeatedly to get it out of your way, see the screenshot attached as an example

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/1d0d5874-bdd6-42eb-bf91-ec423954715d" />

It'd be much more helpful if it just quickly informed the user that something went wrong, and directed to the logs to look at the details

P.S.: Thank you for the plugin! It doesn't cease to amaze me with how smoothly it runs & how well thought through it is