### PR TITLE
fix(devtools): stop DevTools server on flutter shutdown

### DIFF
--- a/lua/flutter-tools/dev_tools.lua
+++ b/lua/flutter-tools/dev_tools.lua
@@ -233,6 +233,7 @@ function M.get_profiler_url()
 end
 
 function M.on_flutter_shutdown()
+  M.stop()
   profiler_url = nil
   devtools_profiler_url = nil
 end


### PR DESCRIPTION
on_flutter_shutdown() only cleared profiler_url and devtools_profiler_url but left devtools_url, devtools_pid, and the DevTools server process alive. After quit and relaunch in debug mode, the stale devtools_url caused the browser to open with the old port instead of the new one.

Call M.stop() in on_flutter_shutdown() to kill the DevTools process and clear all state so the next launch starts fresh.

fixes https://github.com/nvim-flutter/flutter-tools.nvim/issues/520#issue-4097271329