### PR TITLE
fix(commands): prevent false positive "Flutter is already running!" s…

### DIFF
--- a/lua/flutter-tools/commands.lua
+++ b/lua/flutter-tools/commands.lua
@@ -94,6 +94,7 @@ end
 ---@param project_config flutter.ProjectConfig?
 ---@param launch_config dap.Configuration?
 local function on_run_exit(result, cli_args, opts, project_config, launch_config)
+  shutdown()
   local matched_error, msg = has_recoverable_error(result)
   if matched_error then
     local lines = devices.to_selection_entries(result)
@@ -110,7 +111,6 @@ local function on_run_exit(result, cli_args, opts, project_config, launch_config
       end,
     })
   end
-  shutdown()
 end
 
 --- Take arguments from the commandline and pass


### PR DESCRIPTION
## Fixed "Flutter is already running!" when retrying after device pick

## What was happening

Sometimes `flutter run` exits with:

- `No supported devices connected`
- `More than one device connected`

When this happens, the plugin opens a small picker so you can pick a
device, then automatically retries the run with `-d <your-device>`.

The retry was failing with `Flutter is already running!`, even though
nothing was actually running.

## Why

The plugin clears its internal runner state inside `on_run_exit`, but
it was doing it *after* showing the device picker:

```lua
local function on_run_exit(result, cli_args, opts, project_config, launch_config)
  local matched_error, msg = has_recoverable_error(result)
  if matched_error then
    ui.select({ ... })   -- opens picker (async, returns immediately)
  end
  shutdown()              -- runs too late
end
```

`ui.select` is asynchronous — it shows the picker, then waits for you
to pick. Your pick runs later in a callback, and that callback calls
`M.run` to retry. But `shutdown()` hadn't run yet, so the plugin still
thought a runner was active. The retry hit the `is_running()` guard
and bailed.

## Fix

Move `shutdown()` to run *before* the picker:

```lua
local function on_run_exit(result, cli_args, opts, project_config, launch_config)
  shutdown()              -- clear state first
  local matched_error, msg = has_recoverable_error(result)
  if matched_error then
    ui.select({ ... })
  end
end
```

Now by the time the picker callback fires and the retry starts, the
old state is already gone and the retry can proceed.

***Also tested it for two days at work, to make sure the fix works!***

Thank you for your work!